### PR TITLE
chore(blog): recategorize multi-agent AI workflow post

### DIFF
--- a/blogs/ai/2026-05-15.md
+++ b/blogs/ai/2026-05-15.md
@@ -2,7 +2,7 @@
 title: 我把 Claude、Codex、Copilot、Gemini 拼成了一个工作流，接力写代码
 date: 2026-05-15 16:00:00
 categories:
-  - AI 前沿
+  - AI和机器学习
 tags:
   - AI
   - Agent


### PR DESCRIPTION
Move `2026-05-15.md` from `blogs/ai-frontier/` to `blogs/ai/` and update its category from "AI 前沿" to "AI和机器学习". Post content is unchanged.